### PR TITLE
Update readme + sdk pin 

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,15 @@ Thanks
 
 ### Prerequisites
 
-1. Python
-2. Planet SDK
+1. Python 3.11 or higher
 
-To install the Planet SDK and MCP server, use `pip` or your preferred package manager:
+To install the Planet MCP server, use `pip` or your preferred package manager:
 
 ```
-pip install planet planet-mcp
+pip install planet-mcp
 ```
+
+This will also install the planet SDK.
 
 ### Authentication
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ readme = "README.md"
 dependencies = [
     "aiocache>=0.12.3",
     "fastmcp==2.11.0",
-    "planet==3.0.0",
+    "planet>=3.0.0",
     "uv",
     "mercantile>=1.2.1",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11"
 
 [[package]]
@@ -777,7 +777,7 @@ requires-dist = [
     { name = "aiocache", specifier = ">=0.12.3" },
     { name = "fastmcp", specifier = "==2.11.0" },
     { name = "mercantile", specifier = ">=1.2.1" },
-    { name = "planet", specifier = "==3.0.0" },
+    { name = "planet", specifier = ">=3.0.0" },
     { name = "uv" },
 ]
 


### PR DESCRIPTION
- don't need to install planet sdk with the mcp server
- pin to at least 3.0 of the python sdk.