### PR TITLE
simplify geom inputs for tools

### DIFF
--- a/src/planet_mcp/models.py
+++ b/src/planet_mcp/models.py
@@ -5,3 +5,4 @@ from typing_extensions import TypedDict
 class Geometry(TypedDict):
     type: str
     coordinates: Any
+    content: str | None

--- a/src/planet_mcp/models.py
+++ b/src/planet_mcp/models.py
@@ -1,0 +1,11 @@
+from typing_extensions import Literal, TypedDict
+
+
+class Polygon(TypedDict):
+    type: Literal["Polygon"]
+    coordinates: list[list[list[float]]]
+
+
+class Point(TypedDict):
+    type: Literal["Point"]
+    coordinates: list[float]

--- a/src/planet_mcp/models.py
+++ b/src/planet_mcp/models.py
@@ -1,11 +1,7 @@
-from typing_extensions import Literal, TypedDict
+from typing import Any
+from typing_extensions import TypedDict
 
 
-class Polygon(TypedDict):
-    type: Literal["Polygon"]
-    coordinates: list[list[list[float]]]
-
-
-class Point(TypedDict):
-    type: Literal["Point"]
-    coordinates: list[float]
+class Geometry(TypedDict):
+    type: str
+    coordinates: Any

--- a/src/planet_mcp/servers/sdk.py
+++ b/src/planet_mcp/servers/sdk.py
@@ -10,7 +10,6 @@ import planet
 from typing import Union
 
 
-
 # tools we don't want enabled at all.
 # they simply don't work well in an AI context.
 _DEFAULT_IGNORE = {

--- a/src/planet_mcp/servers/sdk.py
+++ b/src/planet_mcp/servers/sdk.py
@@ -3,6 +3,7 @@ import inspect
 from types import NoneType
 import typing
 
+from planet_mcp import models
 from planet_mcp.clients import session
 from . import descriptions
 from fastmcp import FastMCP
@@ -149,8 +150,8 @@ def _create_param_modified_wrapper(original_func):
             if param_name in ("feature", "quad", "mosaic", "series"):
                 wrapper.__annotations__[param_name] = dict
             elif param_name == "geometry" and "planet.models" in str(param.annotation):
-                # llms should always submit geometry inputs as a dict
-                hint = dict
+                # llms should always submit geometry inputs as a Polygon or Point
+                hint = models.Polygon | models.Point
 
                 # add None if originally used (NoneType will be an arg
                 # within a Union type)

--- a/src/planet_mcp/servers/sdk.py
+++ b/src/planet_mcp/servers/sdk.py
@@ -1,5 +1,7 @@
 import functools
 import inspect
+from types import NoneType
+import typing
 
 from planet_mcp.clients import session
 from . import descriptions
@@ -23,6 +25,19 @@ _DEFAULT_IGNORE = {
     "subscriptions_update_subscription",
     "mosaics_get_quad_contributions",
     "destinations_patch_destination",
+}
+
+# tools with signatures we want to simplify for LLM usage
+TOOL_SIG_OVERRIDE = {
+    "features_add_items",
+    "data_get_item_coverage",
+    "data_search",
+    "mosaics_download_quad",
+    "mosaics_download_quads",
+    "mosaics_get_quad",
+    "mosaics_list_quads",
+    "mosaics_list_series_mosaics",
+    "mosaics_summarize_quads",
 }
 
 SDK_CLIENTS = [
@@ -80,15 +95,12 @@ def make_tools(mcp: FastMCP, client_class: type, prefix: str):
                 if tag in full_name:
                     opts["tags"].add(tag)
 
-            try:
-                mcp.tool(func, name=full_name, **opts)
-            except PydanticSchemaGenerationError:
-                # there's a few functions we need to modify again because of custom types.
-                modified_func = _create_param_modified_wrapper(func)
-                try:
-                    mcp.tool(modified_func, name=full_name, **opts)
-                except Exception as e:
-                    print("Unable to add tool", full_name, e)
+            # some tools have function signatures that need to be
+            # modified/simplified.
+            if full_name in TOOL_SIG_OVERRIDE:
+                func = _create_param_modified_wrapper(func)
+
+            mcp.tool(func, name=full_name, **opts)
 
 
 def _async_get_wrapper(f, prefix):
@@ -115,9 +127,14 @@ def _return_wrapper(func):
 
 def _create_param_modified_wrapper(original_func):
     """
-    Some functions that accept special types (typing.Protocol) fail during
-    FastMCP tool registration. This wrapper modifies the function's signature,
-    replacing the type hints with simple types that FastMCP can handle.
+    Create a wrapper function with a modified signature using types that
+    are compatible with FastMCP and/or easier for LLMs to work with.
+
+    * FastMCP tool registration doesn't support Protocol types.
+    * the Planet SDK is flexible with geometry inputs (accepting either feature ref
+      strings, geojson dicts or shapely-like geometries), but for LLM tool usage
+      we generally want geojson as an object/dict. Our tests have shown better
+      and more consistent results when tool inputs use dicts only.
     """
 
     @functools.wraps(original_func)
@@ -134,7 +151,16 @@ def _create_param_modified_wrapper(original_func):
             if param_name in ("feature", "quad", "mosaic", "series"):
                 wrapper.__annotations__[param_name] = dict
             elif param_name == "geometry" and "planet.models" in str(param.annotation):
-                wrapper.__annotations__[param_name] = Optional[Union[dict, str]] | None
+                # llms should always submit geometry inputs as a dict
+                hint = dict
+
+                # add None if originally used (NoneType will be an arg
+                # within a Union type)
+                if typing.get_origin(
+                    param.annotation
+                ) is Union and NoneType in typing.get_args(param.annotation):
+                    hint = hint | None
+                wrapper.__annotations__[param_name] = hint
 
     except Exception as e:
         print(f"Error modifying signature: {e}")

--- a/src/planet_mcp/servers/sdk.py
+++ b/src/planet_mcp/servers/sdk.py
@@ -7,9 +7,8 @@ from planet_mcp.clients import session
 from . import descriptions
 from fastmcp import FastMCP
 import planet
-from typing import Union, Optional
+from typing import Union
 
-from pydantic import PydanticSchemaGenerationError
 
 
 # tools we don't want enabled at all.

--- a/src/planet_mcp/servers/sdk.py
+++ b/src/planet_mcp/servers/sdk.py
@@ -150,8 +150,8 @@ def _create_param_modified_wrapper(original_func):
             if param_name in ("feature", "quad", "mosaic", "series"):
                 wrapper.__annotations__[param_name] = dict
             elif param_name == "geometry" and "planet.models" in str(param.annotation):
-                # llms should always submit geometry inputs as a Polygon or Point
-                hint = models.Polygon | models.Point
+                # llms should always submit geometry inputs as a geojson geometry
+                hint = models.Geometry
 
                 # add None if originally used (NoneType will be an arg
                 # within a Union type)


### PR DESCRIPTION
We previously had some code to simplify tool input schemas (generated from the SDK function signatures) if tool registration failed. We also now want to simplify our geojson input type hints due to inconsistent behavior using geojson inputs with Claude Desktop.

Since we have another reason to run tool functions through the `_create_param_modified_wrapper` utility, I set up a list of tools to use it with (rather than relying on `PydanticSchemaGenerationError` to trigger it).
