### PR TITLE
modify search to fix claude issues

### DIFF
--- a/src/planet_mcp/servers/__init__.py
+++ b/src/planet_mcp/servers/__init__.py
@@ -1,7 +1,9 @@
 from . import sdk
 from . import tiles
+from . import search
 
 all = [
     sdk,
     tiles,
+    search,
 ]

--- a/src/planet_mcp/servers/descriptions.py
+++ b/src/planet_mcp/servers/descriptions.py
@@ -20,11 +20,14 @@ overrides = {
         }
         ```
 
-    search_filter: a Planet Data API filter for advanced searches.
+    start_date: An optional datestring to use as the start date for the search. Use ISO 8601 format, e.g. 2022-04-14T00:00:00Z.
+    end_date: An optional datestring to use as the end date for the search. Use ISO 8601 format. If not provided, searches from start_date onwards.
 
     If the user does not ask for specific item types, default to ["PSScene", "SkySatScene", "SkySatCollect"].
 
     Avoid using search_filter unless the user has asked for specific date ranges or other advanced parameters. If a
     user asks for a scene from "today", do a search as normal and present the first (most recent) result.
+
+    Note: The search automatically filters for cloud_cover <= 0.2 (20%).
     """
 }

--- a/src/planet_mcp/servers/sdk.py
+++ b/src/planet_mcp/servers/sdk.py
@@ -10,7 +10,6 @@ from fastmcp import FastMCP
 import planet
 from typing import Union
 
-
 # tools we don't want enabled at all.
 # they simply don't work well in an AI context.
 _DEFAULT_IGNORE = {
@@ -19,6 +18,7 @@ _DEFAULT_IGNORE = {
     "data_get_search",
     "data_get_stats",
     "data_list_searches",
+    "data_search",
     "data_update_search",
     "data_wait_asset",
     "destinations_patch_destination",
@@ -35,7 +35,6 @@ _DEFAULT_IGNORE = {
 TOOL_SIG_OVERRIDE = {
     "features_add_items",
     "data_get_item_coverage",
-    "data_search",
     "mosaics_download_quad",
     "mosaics_download_quads",
     "mosaics_get_quad",

--- a/src/planet_mcp/servers/search.py
+++ b/src/planet_mcp/servers/search.py
@@ -17,7 +17,7 @@ mcp = FastMCP("sdk")
 )
 async def data_search(
     item_types: list[str],
-    start_date: str,
+    start_date: str | None,
     end_date: str | None,
     geometry: models.Geometry,
 ):

--- a/src/planet_mcp/servers/search.py
+++ b/src/planet_mcp/servers/search.py
@@ -1,0 +1,57 @@
+from datetime import datetime
+
+from fastmcp import FastMCP
+from planet import Planet
+from planet_mcp import models
+from planet_mcp.servers import descriptions
+
+# technically not using the sdk to make the tool but we can add it to that
+
+mcp = FastMCP("sdk")
+
+
+@mcp.tool(
+    name="data_search",
+    description=descriptions.overrides["data_search"],
+    tags={"data", "search"},
+)
+async def data_search(
+    item_types: list[str],
+    start_date: str,
+    end_date: str | None,
+    geometry: models.Geometry,
+):
+
+    planet = Planet()
+    cloud_filter = {
+        "type": "RangeFilter",
+        "field_name": "cloud_cover",
+        "config": {"lte": 0.2},
+    }
+    filter = {
+        "type": "AndFilter",
+        "config": [cloud_filter],
+    }
+    if start_date is not None or end_date is not None:
+        datefilter_config = {}
+        if start_date is not None:
+            datefilter_config["gte"] = datetime.fromisoformat(
+                start_date.replace("Z", "+00:00")
+            ).isoformat()
+        if end_date is not None:
+            datefilter_config["lte"] = datetime.fromisoformat(
+                end_date.replace("Z", "+00:00")
+            ).isoformat()
+        datefilter = {
+            "type": "DateRangeFilter",
+            "field_name": "acquired",
+            "config": datefilter_config,
+        }
+        filter["config"].append(datefilter)
+
+    results = planet.data.search(
+        item_types=item_types,
+        geometry=dict(geometry),
+        search_filter=filter,
+    )
+    return results

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -18,6 +18,14 @@ async def test_search_tool():
     )
     async with client:
         result = await client.call_tool(
-            "sdk_data_search", {"item_types": ["SkySatScene"]}
+            "sdk_data_search",
+            {
+                "item_types": ["SkySatScene"],
+                "start_date": "2023-01-01",
+                "end_date": "2023-01-02",
+                "geometry": {"type": "Point", "coordinates": [0, 0], "content": None},
+            },
         )
-    assert result.structured_content == {"result": [{"type": "Feature"}]}
+    assert len(result.content) == 1
+    assert result.content[0].type == "text"
+    assert result.content[0].text == '[{"type":"Feature"}]'


### PR DESCRIPTION
override the data_search sdk method to hopefully fix issues with claude desktop not using search filters correctly. 

I still added the method to the 'sdk' mcp server, this is up for review if it should be it's own or not. 

~need someone with claude desktop to confirm fix~ this has been done! 